### PR TITLE
FEAT: add user_id to auditlog

### DIFF
--- a/src/middleware/auditLogging.js
+++ b/src/middleware/auditLogging.js
@@ -12,6 +12,7 @@ exports.auditLogMiddleware = (req, res, next) => {
     const originalJson = res.json;
     res.json = async function (body){
       await db.AuditLog.create({
+        user_id: req.user.user_id,
         url: req.originalUrl,
         activity: methodMappers[req.method] + ' ' + req.originalUrl.split("/")[req.originalUrl.split("/").length - 1] || "",
         params: JSON.stringify(req.params),

--- a/src/migrations/20241115180454-update-column-auditlog.js
+++ b/src/migrations/20241115180454-update-column-auditlog.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return Promise.all([
+      queryInterface.addColumn("AuditLog", "user_id", {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+      })
+    ])
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    return Promise.all([
+      queryInterface.removeColumn("AuditLog", "user_id")
+    ])
+  }
+};

--- a/src/models/auditlog.js
+++ b/src/models/auditlog.js
@@ -11,9 +11,20 @@ module.exports = (sequelize, DataTypes) => {
      */
     static associate(models) {
       // define association here
+      AuditLog.belongsTo(models.User, {
+        foreignKey: "user_id",
+        as: "user",
+      });
     }
   };
   AuditLog.init({
+    user_id: {
+      type: DataTypes.INTEGER,
+      references: {
+        model: "User",
+        key: "id",
+      },
+    },
     url: {
       type: DataTypes.STRING,
       allowNull: true

--- a/src/models/vehicle.js
+++ b/src/models/vehicle.js
@@ -23,7 +23,7 @@ module.exports = (sequelize, DataTypes) => {
     capacity: DataTypes.INTEGER,
     kilometer_driven: DataTypes.DOUBLE,
     parking_id: {
-      type: DataTypes.INTEGER,
+      type: DataTypes.UUID,
       allowNull: true,
     },
   }, {


### PR DESCRIPTION
- Added column `user_id` to `AuditLog`. `AuditLog` now tracks the ID of the user requesting the API.
- Fixed `parking_id` value in association.